### PR TITLE
Typo

### DIFF
--- a/lib/rubocop/cop/inclusivity/race.rb
+++ b/lib/rubocop/cop/inclusivity/race.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Inclusivity
-      # Detects potentially insensitive langugae used in variable names and
+      # Detects potentially insensitive language used in variable names and
       # suggests alternatives that promote inclusivity.
       #
       # The `Offenses` config parameter can be used to configure the cop with


### PR DESCRIPTION
This fixes a typo in the API documentation. langugae -> language